### PR TITLE
Support HSequential

### DIFF
--- a/src/types_to_schema/core.clj
+++ b/src/types_to_schema/core.clj
@@ -152,6 +152,8 @@
               (throw (ex-info  "Cannot generate predicate for dotted HVec" {:type ::ast->schema}))
               (vec (concat (map-indexed (fn [idx ti] (s/one (ast->schema ti name-env) (str "idx " idx))) (:types t))
                            (when (:rest t) [(ast->schema (:rest t) name-env)]))))
+    (:HSequential) (s/both (s/pred sequential? 'sequential?)
+                           (ast->schema (assoc t :op :HVec) name-env))
     (:CountRange) (s/both (s/either (s/eq nil)
                                     (s/pred coll? 'coll?))
                           (s/pred (if (:upper t)

--- a/src/types_to_schema/core.clj
+++ b/src/types_to_schema/core.clj
@@ -204,7 +204,9 @@
                               [[s/Any s/Any]]))))]
         (if (empty? (:absent-keys t))
           base-scm
-          (err/int-error (str "Cannot generate predicate for :absent-keys"))))
+          (let [absent-keys (set (map :val (:absent-keys t)))
+                pred (fn [m] (not (some absent-keys (keys m))))]
+            (s/both base-scm (s/pred pred "absent-keys")))))
     (:Rec) (throw (ex-info  "Cannot generate predicate for recursive types" {:type ::ast->schema}))
     (throw (ex-info (str op " not supported in type->pred: " (:form t)) {:type ::ast->schema}))))
 

--- a/test/types_to_schema/core_test.clj
+++ b/test/types_to_schema/core_test.clj
@@ -19,10 +19,11 @@
       "tests that recursive types work")
   (is (= '{:test :testing-hmap} (s/validate (schema '{:test t/Keyword}) '{:test :testing-hmap})))
   (is (= '["hey" 12] (s/validate (schema '[String Number]) '["hey" 12])))
+  (is (thrown? Exception (s/validate (schema '[String Number]) '("hey" 12))))
   (is (= '["hey" 12] (s/validate (schema (t/HSequential [t/Str t/Int]))
                                  '["hey" 12])))
-  (is (= '("hey" 12) (s/validate (schema (t/HVec [t/Str t/Int]))
-                                 '("hey" 12)))))
+  (is (= '["hey" 12] (s/validate (schema (t/HSeq [t/Str t/Int]))
+                                 '["hey" 12]))))
 
 (deftest test-wrapped-functions
   (let [counter @function-calls]

--- a/test/types_to_schema/core_test.clj
+++ b/test/types_to_schema/core_test.clj
@@ -18,7 +18,9 @@
   (is (= (list (list nil)) (s/validate (schema TestRecursiveAlias) (list (list nil))))
       "tests that recursive types work")
   (is (= '{:test :testing-hmap} (s/validate (schema '{:test t/Keyword}) '{:test :testing-hmap})))
-  (is (= '["hey" 12] (s/validate (schema '[String Number]) '["hey" 12]))))
+  (is (= '["hey" 12] (s/validate (schema '[String Number]) '["hey" 12])))
+  (is (= '["hey" 12] (s/validate (schema (t/HSequential [t/Str t/Int]))
+                                 '["hey" 12]))))
 
 (deftest test-wrapped-functions
   (let [counter @function-calls]

--- a/test/types_to_schema/core_test.clj
+++ b/test/types_to_schema/core_test.clj
@@ -23,7 +23,8 @@
   (is (= '["hey" 12] (s/validate (schema (t/HSequential [t/Str t/Int]))
                                  '["hey" 12])))
   (is (= '["hey" 12] (s/validate (schema (t/HSeq [t/Str t/Int]))
-                                 '["hey" 12]))))
+                                 '["hey" 12])))
+  (is (nil? (s/check (schema (t/NonEmptyLazySeq t/Int)) (map inc (range))))))
 
 (deftest test-wrapped-functions
   (let [counter @function-calls]

--- a/test/types_to_schema/core_test.clj
+++ b/test/types_to_schema/core_test.clj
@@ -20,7 +20,9 @@
   (is (= '{:test :testing-hmap} (s/validate (schema '{:test t/Keyword}) '{:test :testing-hmap})))
   (is (= '["hey" 12] (s/validate (schema '[String Number]) '["hey" 12])))
   (is (= '["hey" 12] (s/validate (schema (t/HSequential [t/Str t/Int]))
-                                 '["hey" 12]))))
+                                 '["hey" 12])))
+  (is (= '("hey" 12) (s/validate (schema (t/HVec [t/Str t/Int]))
+                                 '("hey" 12)))))
 
 (deftest test-wrapped-functions
   (let [counter @function-calls]

--- a/test/types_to_schema/core_test.clj
+++ b/test/types_to_schema/core_test.clj
@@ -24,7 +24,9 @@
                                  '["hey" 12])))
   (is (= '["hey" 12] (s/validate (schema (t/HSeq [t/Str t/Int]))
                                  '["hey" 12])))
-  (is (nil? (s/check (schema (t/NonEmptyLazySeq t/Int)) (map inc (range))))))
+  (is (nil? (s/check (schema (t/NonEmptyLazySeq t/Int)) (map inc (range)))))
+  (is (nil? (s/check (schema (t/HMap :absent-keys #{:foo :bar})) {:not "foo"})))
+  (is (not (nil? (s/check (schema (t/HMap :absent-keys #{:foo :bar})) {:foo "foo"})))))
 
 (deftest test-wrapped-functions
   (let [counter @function-calls]


### PR DESCRIPTION
HSequential and HVec are just like HSeq except they add a predicate for sequential? and vector?, respectively. NonEmptyLazySeq uses both a predicate for instanceof LazySeq (slightly stronger than what core.typed does itself, but both appear to exclude e.g. (range) proper) and tests the first value in the seq against the type.
